### PR TITLE
Make quoted strings optional in YAML linting

### DIFF
--- a/configs/.yamllint.yaml
+++ b/configs/.yamllint.yaml
@@ -32,7 +32,7 @@ rules:
     forbid-implicit-octal: true
   quoted-strings:
     quote-type: double
-    required: true
+    required: false
   trailing-spaces: enable
   truthy:
     level: warning


### PR DESCRIPTION
This change modifies the `.yamllint.yaml` configuration file to make quoted strings optional rather than required. The `quoted-strings` rule's `required` parameter has been set to `false`, allowing for more flexibility in YAML formatting while maintaining the preference for double quotes when strings are quoted.
