### PR TITLE
Allow "on" as truthy value in YAML linting

### DIFF
--- a/configs/.yamllint.yaml
+++ b/configs/.yamllint.yaml
@@ -35,4 +35,5 @@ rules:
     required: false
   trailing-spaces: enable
   truthy:
+    allowed-values: ["true", "false", "on"]
     level: warning


### PR DESCRIPTION
This change modifies the `.yamllint.yaml` configuration file to allow "on" as a valid truthy value in addition to "true" and "false". The `truthy` rule is updated to include these allowed values while maintaining its warning level. This adjustment provides more flexibility in YAML files that may use "on" as a valid boolean representation.
