### PR TITLE
Update markdownlint config rules

### DIFF
--- a/configs/.markdownlint.yaml
+++ b/configs/.markdownlint.yaml
@@ -1,15 +1,17 @@
 # Autoformatter friendly markdownlint config (all formatting rules disabled)
 default: true
-blank_lines: false
 bullet: false
 first-line-heading: false
 html: false
 indentation: false
 line_length: false
+no-duplicate-header: false
 no-duplicate-heading: false
+no-emphasis-as-header: false
 no-emphasis-as-heading: false
+no-hard-tabs: false
 no-trailing-punctuation: false
+single-h1: false
 single-title: false
 spaces: false
 url: false
-whitespace: false


### PR DESCRIPTION
This pull request updates the Markdownlint configuration file to adjust linting rules. The changes include:

1. Removing the `blank_lines` rule
2. Adding `no-duplicate-header` rule and setting it to false
3. Adding `no-emphasis-as-header` rule and setting it to false
4. Adding `no-hard-tabs` rule and setting it to false
5. Adding `single-h1` rule and setting it to false
6. Removing the `whitespace` rule

These adjustments aim to provide more flexibility in Markdown formatting while maintaining essential linting checks.
